### PR TITLE
add 'How to Cite' section to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -257,7 +257,7 @@ If you use oHySEM in your research, please cite the following publication:
 .. code-block:: bibtex
 
     @INPROCEEDINGS{10608848,
-      author={Álvarez, Erik F. and Sánchez-Martín, Pedro and Ramos, Andrés},
+      author={Alvarez, Erik F. and Sánchez-Martín, Pedro and Ramos, Andrés},
       booktitle={2024 20th International Conference on the European Energy Market (EEM)},
       title={Self-Scheduling for a Hydrogen-Based Virtual Power Plant in Day-Ahead Energy and Reserve Electricity Markets},
       year={2024},

--- a/README.rst
+++ b/README.rst
@@ -244,3 +244,12 @@ License
 =======
 
 oHySEM is licensed under the GPL-3.0 license. See the `LICENSE file <https://github.com/IIT-EnergySystemModels/oHySEM/blob/main/LICENSE>`_ for details.
+
+---
+
+How to Cite
+===========
+
+If you use oHySEM in your research, please cite the following publication:
+
+- E.F. Alvarez, P. Sánchez-Martín and A. Ramos, "Self-Scheduling for a Hydrogen-Based Virtual Power Plant in Day-Ahead Energy and Reserve Electricity Markets," 20th International Conference on the European Energy Market (EEM), Istanbul, Turkiye, June 2024, pp. 1-6, `10.1109/EEM60825.2024.10608848 <https://doi.org/10.1109/EEM60825.2024.10608848>`_.

--- a/README.rst
+++ b/README.rst
@@ -254,7 +254,9 @@ If you use oHySEM in your research, please cite the following publication:
 
 - E.F. Alvarez, P. Sánchez-Martín and A. Ramos, "Self-Scheduling for a Hydrogen-Based Virtual Power Plant in Day-Ahead Energy and Reserve Electricity Markets," 20th International Conference on the European Energy Market (EEM), Istanbul, Turkiye, June 2024, pp. 1-6, `10.1109/EEM60825.2024.10608848 <https://doi.org/10.1109/EEM60825.2024.10608848>`_.
 
-.. code-block:: bibtex
+BibTeX entry:
+**************
+.. code::
 
     @INPROCEEDINGS{10608848,
       author={Alvarez, Erik F. and Sánchez-Martín, Pedro and Ramos, Andrés},

--- a/README.rst
+++ b/README.rst
@@ -253,3 +253,16 @@ How to Cite
 If you use oHySEM in your research, please cite the following publication:
 
 - E.F. Alvarez, P. Sánchez-Martín and A. Ramos, "Self-Scheduling for a Hydrogen-Based Virtual Power Plant in Day-Ahead Energy and Reserve Electricity Markets," 20th International Conference on the European Energy Market (EEM), Istanbul, Turkiye, June 2024, pp. 1-6, `10.1109/EEM60825.2024.10608848 <https://doi.org/10.1109/EEM60825.2024.10608848>`_.
+
+.. code-block:: bibtex
+
+    @INPROCEEDINGS{10608848,
+      author={Álvarez, Erik F. and Sánchez-Martín, Pedro and Ramos, Andrés},
+      booktitle={2024 20th International Conference on the European Energy Market (EEM)},
+      title={Self-Scheduling for a Hydrogen-Based Virtual Power Plant in Day-Ahead Energy and Reserve Electricity Markets},
+      year={2024},
+      volume={},
+      number={},
+      pages={1-6},
+      doi={10.1109/EEM60825.2024.10608848}
+    }


### PR DESCRIPTION
This PR adds a 'How to Cite' section to the README.rst file to provide a citation for the oHySEM model.